### PR TITLE
Add classifier support for ArtifactPromotionPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ job {
 	    artifactPromotion {
 	      groupId(String groupId)
 	      artifactId(String artifactId)
+	      classifier(String classifier)
 	      version(String version)
 	      extension(String extension = "jar")
 	      stagingRepository(String url, String user, String password, boolean skipDeletion = false)
@@ -49,6 +50,10 @@ job('example') {
 	}
 }
 ```
+
+## Artifact deletion
+When you promote artifacts from the staging to the release repository you may want to remove the artifact from staging. If your artifact only has one associated file, the plugin works as expected.
+Although if you're using classifiers, deletion removes all files associated with the artifact. The 'Skip deletion' option reserves the files in the staging repository. Untick 'Skip deletion' only after you've promoted all the relevant files in prevous steps. Use a promotion step for each classifier.
 
 # Contributions
 Please feel free to contribute for other repository servers like

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
 
     <properties>
         <aetherVersion>1.0.0.v20140518</aetherVersion>
+        <commonsIoVersion>1.4</commonsIoVersion>
         <mavenVersion>3.1.0</mavenVersion>
         <wagonVersion>1.0</wagonVersion>
         <jerseyVersion>1.9.1</jerseyVersion>
@@ -121,6 +122,12 @@
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-transport-wagon</artifactId>
             <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commonsIoVersion}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/AetherInteraction.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/AetherInteraction.java
@@ -25,11 +25,15 @@ package org.jenkinsci.plugins.artifactpromotion;
 import hudson.model.BuildListener;
 import hudson.util.Secret;
 
+import java.io.File;
+import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
@@ -57,6 +61,8 @@ import org.eclipse.aether.util.repository.AuthenticationBuilder;
  */
 public class AetherInteraction {
 	
+        private final static String TEMP_DIR_PREFIX = "artifactpromotion";
+
 	private BuildListener listener;
         
     public AetherInteraction(BuildListener listener) {
@@ -79,9 +85,43 @@ public class AetherInteraction {
             final RemoteRepository releaseRepo, final Artifact artifact, final Artifact pom) throws DeploymentException {
         
         DeployRequest deployRequest = new DeployRequest();
-        deployRequest.addArtifact(artifact).addArtifact(pom);
-        deployRequest.setRepository(releaseRepo);
-        return system.deploy(session, deployRequest);
+        deployRequest.addArtifact(artifact);
+
+        String tempName = null;
+        File tempDirectory = null;
+        try {
+            this.listener.getLogger().println("Checking if POM already exists in releaserepo");
+
+            File tempFile = File.createTempFile(TEMP_DIR_PREFIX, null);
+            tempName = tempFile.getCanonicalPath();
+            tempFile.delete();
+            tempDirectory = new File(tempName);
+            tempDirectory.mkdir();
+
+            DefaultRepositorySystemSession testSession = MavenRepositorySystemUtils.newSession();
+            LocalRepository tempRepo = new LocalRepository(tempDirectory);
+            testSession.setLocalRepositoryManager(system.newLocalRepositoryManager(testSession, tempRepo));
+
+            Artifact testPom = getArtifact(testSession, system, releaseRepo, pom.getGroupId(), pom.getArtifactId(), null,
+                    ArtifactPromotionBuilder.POMTYPE, pom.getVersion());
+        } catch(IOException e) {
+            this.listener.getLogger().println("Cannot create temp file, POM file will be deployed");
+            deployRequest.addArtifact(pom);
+        } catch(ArtifactResolutionException e) {
+            this.listener.getLogger().println("POM doesn't exist in release repo, it will be deployed");
+            deployRequest.addArtifact(pom);
+        } finally {
+            if (tempDirectory != null) {
+                try {
+                    FileUtils.deleteDirectory(tempDirectory);
+                } catch(IOException e) {
+                    this.listener.getLogger().println("Cannot delete temp file: " + tempName);
+                }
+            }
+
+            deployRequest.setRepository(releaseRepo);
+            return system.deploy(session, deployRequest);
+        }
     }
 
     /** Get ('resolve') the artifact from a repository server.
@@ -94,16 +134,17 @@ public class AetherInteraction {
      * @param remoteRepos
      * @param groupId
      * @param artifactId
+     * @param classifier
      * @param type
      * @param version
      * @return
      * @throws ArtifactResolutionException
      */
     protected Artifact getArtifact(final RepositorySystemSession session, RepositorySystem system,
-            final RemoteRepository remoteRepo, final String groupId, final String artifactId, final String type,
-            final String version) throws ArtifactResolutionException {
+            final RemoteRepository remoteRepo, final String groupId, final String artifactId, final String classifier,
+            final String type, final String version) throws ArtifactResolutionException {
 
-        Artifact artifact = new DefaultArtifact(groupId + ":" + artifactId + ":" + type + ":" + version);
+        Artifact artifact = new DefaultArtifact(groupId, artifactId, classifier, type, version);
         ArtifactRequest artifactRequest = new ArtifactRequest();
         artifactRequest.setArtifact(artifact);      
         artifactRequest.setRepositories(new ArrayList<RemoteRepository>(Arrays.asList(remoteRepo)));

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionBuilder.java
@@ -65,6 +65,7 @@ public class ArtifactPromotionBuilder extends Builder {
 
 	private final String groupId;
 	private final String artifactId;
+	private final String classifier;
 	private final String version;
 	private final String extension;
 
@@ -131,6 +132,8 @@ public class ArtifactPromotionBuilder extends Builder {
 	 *            The groupId of the artifact
 	 * @param artifactId
 	 *            The artifactId of the artifact.
+	 * @param classifier
+	 *            The classifier of the artifact.
 	 * @param version
 	 *            The version of the artifact.
 	 * @param extension
@@ -153,7 +156,7 @@ public class ArtifactPromotionBuilder extends Builder {
 	 *            Flag for debug output. Currently not used.
 	 */
 	@DataBoundConstructor
-	public ArtifactPromotionBuilder(String groupId, String artifactId,
+	public ArtifactPromotionBuilder(String groupId, String artifactId, String classifier,
 			String version, String extension, String stagingRepository,
 			String stagingUser, Secret stagingPW, String releaseUser,
 			Secret releasePW, String releaseRepository, String promoterClass,
@@ -161,6 +164,7 @@ public class ArtifactPromotionBuilder extends Builder {
 				
 		this.groupId = groupId;
 		this.artifactId = artifactId;
+		this.classifier = classifier;
 		this.version = version;
 		this.extension = extension == null ? "jar" : extension;
 		this.stagingRepository = stagingRepository;
@@ -252,9 +256,11 @@ public class ArtifactPromotionBuilder extends Builder {
 					TokenMacro.expandAll(build, listener, groupId));
 			tokens.put(PromotionBuildTokens.ARTIFACT_ID,
 					TokenMacro.expandAll(build, listener, artifactId));
+			tokens.put(PromotionBuildTokens.CLASSIFIER,
+					TokenMacro.expandAll(build, listener, classifier));
 			tokens.put(PromotionBuildTokens.VERSION,
 					TokenMacro.expandAll(build, listener, version));
-			tokens.put(PromotionBuildTokens.EXTENSION,
+			tokens.put(PromotionBuildTokens.EXTENSION, "".equals(extension) ? "jar" :
 					TokenMacro.expandAll(build, listener, extension));
 			tokens.put(PromotionBuildTokens.STAGING_REPOSITORY,
 					TokenMacro.expandAll(build, listener, stagingRepository));
@@ -405,6 +411,10 @@ public class ArtifactPromotionBuilder extends Builder {
 		return artifactId;
 	}
 
+	public String getClassifier() {
+		return classifier;
+	}
+
 	public String getVersion() {
 		return version;
 	}
@@ -454,6 +464,8 @@ public class ArtifactPromotionBuilder extends Builder {
 		builder.append(groupId);
 		builder.append(", artifactId=");
 		builder.append(artifactId);
+		builder.append(", classifier=");
+		builder.append(classifier);
 		builder.append(", version=");
 		builder.append(version);
 		builder.append(", extension=");

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/NexusOSSPromoterClosure.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/NexusOSSPromoterClosure.java
@@ -113,11 +113,13 @@ public class NexusOSSPromoterClosure implements Serializable, IPromotorClosure {
 			artifact = aether.getArtifact(session, system, stagingRepo,
 					this.expandedTokens.get(PromotionBuildTokens.GROUP_ID),
 					this.expandedTokens.get(PromotionBuildTokens.ARTIFACT_ID),
+					this.expandedTokens.get(PromotionBuildTokens.CLASSIFIER),
 					this.expandedTokens.get(PromotionBuildTokens.EXTENSION),
 					this.expandedTokens.get(PromotionBuildTokens.VERSION));
 			pom = aether.getArtifact(session, system, stagingRepo,
 					this.expandedTokens.get(PromotionBuildTokens.GROUP_ID),
 					this.expandedTokens.get(PromotionBuildTokens.ARTIFACT_ID),
+					null, // POM doesn't have a classifier
 					ArtifactPromotionBuilder.POMTYPE,
 					this.expandedTokens.get(PromotionBuildTokens.VERSION));
 		} catch (ArtifactResolutionException e) {

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/PromotionBuildTokens.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/PromotionBuildTokens.java
@@ -26,6 +26,7 @@ public enum PromotionBuildTokens {
 
 	GROUP_ID,
 	ARTIFACT_ID,
+	CLASSIFIER,
 	VERSION,
 	EXTENSION,
 	STAGING_REPOSITORY,

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionDslContext.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionDslContext.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.artifactpromotion.jobdsl.ArtifactPromotionJobDslExt
 public class ArtifactPromotionDslContext implements Context {
 	private String groupId;
 	private String artifactId;
+	private String classifier;
 	private String version;
 	private String extension = "jar";
 	
@@ -42,6 +43,13 @@ public class ArtifactPromotionDslContext implements Context {
 	}
 	String getArtifactId() {
 		return artifactId;
+	}
+
+	public void classifier(String classifier) {
+		this.classifier = classifier;
+	}
+	String getClassifier() {
+		return classifier;
 	}
 
 	public void version(String version) {

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionJobDslExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionJobDslExtension.java
@@ -25,10 +25,11 @@ public class ArtifactPromotionJobDslExtension extends ContextExtensionPoint {
 		executeInContext(closure, context);
 		
 		return new ArtifactPromotionBuilder(
-				context.getGroupId(), context.getArtifactId(), context.getVersion(), context.getExtension(),
-				context.getStagingRepository(), context.getStagingUser(), context.getStagingPassword(),
-				context.getReleaseUser(), context.getReleasePassword(), context.getReleaseRepository(),
-				context.getPromoterClass(), context.isDebugEnabled(), context.isSkipDeletionEnabled());
+				context.getGroupId(), context.getArtifactId(), context.getClassifier(), context.getVersion(),
+				context.getExtension(), context.getStagingRepository(), context.getStagingUser(),
+				context.getStagingPassword(), context.getReleaseUser(), context.getReleasePassword(),
+				context.getReleaseRepository(), context.getPromoterClass(), context.isDebugEnabled(),
+				context.isSkipDeletionEnabled());
 	}
 	
 	public enum RepositorySystem {

--- a/src/main/resources/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionBuilder/config.jelly
@@ -10,6 +10,10 @@
             <f:textbox />
         </f:entry>
         
+        <f:entry title="Classifier" field="classifier" description="The classifier of the artifact - optional">
+            <f:textbox />
+        </f:entry>
+
         <f:entry title="Version" field="version" description="The version of the artifact">
             <f:textbox />
         </f:entry>
@@ -31,7 +35,7 @@
         </f:entry>
         <f:entry title="Skip deletion" 
                  field="skipDeletion" description="Skip artifact deletion from staging Repository.">
-            <f:checkbox />
+            <f:checkbox default="true" />
         </f:entry>       
     </f:section>
 

--- a/src/main/resources/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionBuilder/help-skipDeletion.html
+++ b/src/main/resources/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionBuilder/help-skipDeletion.html
@@ -1,0 +1,4 @@
+<div>
+  <p>'Skip deletion' option reserves the files in the staging repository.</p>
+  <p>Untick 'Skip deletion' only after you've promoted all the relevant files in previous steps.</p>
+</div>


### PR DESCRIPTION
Hi,

The ArtifactPromotionPlugin currently only supports promoting of the primary artifact. To handle secondary artifacts the 'classifier' coordinate needs to be specified.

I've created a Jira issue for this feature: https://issues.jenkins-ci.org/browse/JENKINS-29623

I believe it's a small change and I've tested it as much as I could. Please consider merging it to the mainline.

Cheers,
Mate