### PR TITLE
Implement optional extension point of JobDSL plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,43 @@ Some guys say this is an anti pattern like in this blog (http://www.alwaysagilec
 # Usage 
 The plugin is in development and should not be used currently for production environments as many parts are subject to change. Especially the support for multiple repository servers will change the GUI and result in some internal refactorings.
 
+## Job DSL
+The plugin adds an extension to the Job DSL plugin to allow defining Artifact Promotion build steps in Job DSL scripts. The extension can be used with the Job DSL plugin version 1.35 or higher.
+
+```
+job {
+	steps {
+	    artifactPromotion {
+	      groupId(String groupId)
+	      artifactId(String artifactId)
+	      version(String version)
+	      extension(String extension = "jar")
+	      stagingRepository(String url, String user, String password, boolean skipDeletion = false)
+	      releaseRepository(String url, String user, String password)
+	      debug(boolean debug)
+	    }
+	}
+}
+```
+
+Creates a build step to promote an artifact from a staging to a release repository.
+
+```
+job('example') {
+	steps {
+		// assumes default repo system (NexusOSS)
+	    artifactPromotion {
+	      groupId("com.example.test")
+	      artifactId("my-artifact")
+	      version("1.0.0")
+	      extension("zip")
+	      stagingRepository("http://nexus.myorg.com:8080/content/repositories/release-candidates", "foo", "s3cr3t")
+	      releaseRepository("http://nexus.myorg.com:8080/content/repositories/releases", "foo", "s3cr3t")
+	    }
+	}
+}
+```
+
 # Contributions
 Please feel free to contribute for other repository servers like
 * Nexus Pro

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <mavenVersion>3.1.0</mavenVersion>
         <wagonVersion>1.0</wagonVersion>
         <jerseyVersion>1.9.1</jerseyVersion>
+        <jobdslVersion>1.35</jobdslVersion>
     </properties>
 
     <dependencies>
@@ -128,7 +129,13 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
             <version>1.6</version>
-        </dependency>        
+        </dependency>
+        <dependency>
+        	<groupId>org.jenkins-ci.plugins</groupId>
+        	<artifactId>job-dsl</artifactId>
+        	<version>${jobdslVersion}</version>
+        	<optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionDslContext.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionDslContext.java
@@ -1,0 +1,107 @@
+package org.jenkinsci.plugins.artifactpromotion.jobdsl;
+
+import hudson.util.Secret;
+import javaposse.jobdsl.dsl.Context;
+
+import org.jenkinsci.plugins.artifactpromotion.jobdsl.ArtifactPromotionJobDslExtension.RepositorySystem;
+
+public class ArtifactPromotionDslContext implements Context {
+	private String groupId;
+	private String artifactId;
+	private String version;
+	private String extension = "jar";
+	
+	private String stagingRepository;
+	private String stagingUser;
+	private Secret stagingPassword;
+	
+	private String releaseRepository;
+	private String releaseUser;
+	private Secret releasePassword;
+	
+	private String promoterClass = RepositorySystem.NexusOSS.getClassName();
+	private boolean debug = false;
+	private boolean skipDeletion = false;
+
+	public void groupId(String groupId) {
+		this.groupId = groupId;
+	}
+	String getGroupId() {
+		return groupId;
+	}
+
+	public void artifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+	String getArtifactId() {
+		return artifactId;
+	}
+
+	public void version(String version) {
+		this.version = version;
+	}
+	String getVersion() {
+		return version;
+	}
+
+	public void extension(String extension) {
+		this.extension = extension;
+	}
+	String getExtension() {
+		return extension;
+	}
+
+	public void stagingRepository(String repository, String user, String password) {
+		this.stagingRepository(repository, user, password, false);
+	}
+	public void stagingRepository(String repository, String user, String password, boolean skipDeletion) {
+		this.stagingRepository = repository;
+		this.stagingUser = user;
+		this.stagingPassword = Secret.fromString(password);
+		this.skipDeletion = skipDeletion;
+	}
+	String getStagingRepository() {
+		return stagingRepository;
+	}
+
+	String getStagingUser() {
+		return stagingUser;
+	}
+
+	Secret getStagingPassword() {
+		return stagingPassword;
+	}
+
+	public void releaseRepository(String repository, String user, String password) {
+		this.releaseRepository = repository;
+		this.releaseUser = user;
+		this.releasePassword = Secret.fromString(password);
+	}
+	String getReleaseRepository() {
+		return releaseRepository;
+	}
+	
+	String getReleaseUser() {
+		return releaseUser;
+	}
+
+	Secret getReleasePassword() {
+		return releasePassword;
+	}
+
+	String getPromoterClass() {
+		return promoterClass;
+	}
+
+	public void debug(boolean debug) {
+		this.debug = debug;
+	}
+	boolean isDebugEnabled() {
+		return debug;
+	}
+
+	boolean isSkipDeletionEnabled() {
+		return skipDeletion;
+	}
+	
+}

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionJobDslExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionJobDslExtension.java
@@ -1,0 +1,38 @@
+package org.jenkinsci.plugins.artifactpromotion.jobdsl;
+
+import org.jenkinsci.plugins.artifactpromotion.ArtifactPromotionBuilder;
+
+import hudson.Extension;
+import javaposse.jobdsl.dsl.helpers.step.StepContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+
+@Extension(optional = true)
+public class ArtifactPromotionJobDslExtension extends ContextExtensionPoint {
+
+	@DslExtensionMethod(context = StepContext.class)
+	public Object artifactPromotion(Runnable closure) {
+		ArtifactPromotionDslContext context = new ArtifactPromotionDslContext();
+		executeInContext(closure, context);
+		
+		return new ArtifactPromotionBuilder(
+				context.getGroupId(), context.getArtifactId(), context.getVersion(), context.getExtension(),
+				context.getStagingRepository(), context.getStagingUser(), context.getStagingPassword(),
+				context.getReleaseUser(), context.getReleasePassword(), context.getReleaseRepository(),
+				context.getPromoterClass(), context.isDebugEnabled(), context.isSkipDeletionEnabled());
+	}
+	
+	public enum RepositorySystem {
+		NexusOSS("org.jenkinsci.artifactpromotion.NexusOSSPromotor");
+		
+		private String className;
+		
+		private RepositorySystem(String className) {
+			this.className = className;
+		}
+		
+		public String getClassName() {
+			return this.className;
+		}
+	}
+}


### PR DESCRIPTION
Add an extension point implementation to add support for the artifact
promotion plugin to the DSL of the JobDsl plugin.

With this change, artifact promotion build steps can be created in Job DSL scripts like this:
```
job('example') {
    steps {
        // assumes default repo system (NexusOSS)
        artifactPromotion {
          groupId("com.example.test")
          artifactId("my-artifact")
          version("1.0.0")
          extension("zip")
          stagingRepository("http://nexus.myorg.com:8080/content/repositories/release-candidates", "foo", "s3cr3t")
          releaseRepository("http://nexus.myorg.com:8080/content/repositories/releases", "foo", "s3cr3t")
        }
    }
}
```