### PR TITLE
Fix NexusOSS promoter classname & add class Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ job('example') {
 }
 ```
 
-*Hint:* If the first Build of the generated Job runs into a `java.lang.ClassNotFoundException: org.jenkinsci.artifactpromotion.NexusOSSPromotor` error you should go into the (generated) project configuration and save the project once.
-
 # Contributions
 Please feel free to contribute for other repository servers like
 * Nexus Pro

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionDslContext.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionDslContext.java
@@ -5,6 +5,13 @@ import javaposse.jobdsl.dsl.Context;
 
 import org.jenkinsci.plugins.artifactpromotion.jobdsl.ArtifactPromotionJobDslExtension.RepositorySystem;
 
+/**
+ * Provides the DSL context to execute the artifactionPromotion closure in.
+ * The public methods of this class can be called from the closure and thus define the DSL vocabulary
+ * inside the artifactPromotion element.
+ *  
+ * @author Patrick Schlebusch
+ */
 public class ArtifactPromotionDslContext implements Context {
 	private String groupId;
 	private String artifactId;

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionJobDslExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/jobdsl/ArtifactPromotionJobDslExtension.java
@@ -1,12 +1,21 @@
 package org.jenkinsci.plugins.artifactpromotion.jobdsl;
 
 import org.jenkinsci.plugins.artifactpromotion.ArtifactPromotionBuilder;
+import org.jenkinsci.plugins.artifactpromotion.NexusOSSPromotor;
 
 import hudson.Extension;
 import javaposse.jobdsl.dsl.helpers.step.StepContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
 
+/**
+ * This class provides the artifactionPromotion DSL extension method.
+ * 
+ * The artifactPromotion keyword can be used with a closure as a build step.
+ * The further vocabulary for the closure is defined in the {@link ArtifactPromotionDslContext}.
+ * 
+ * @author Patrick Schlebusch
+ */
 @Extension(optional = true)
 public class ArtifactPromotionJobDslExtension extends ContextExtensionPoint {
 
@@ -23,7 +32,7 @@ public class ArtifactPromotionJobDslExtension extends ContextExtensionPoint {
 	}
 	
 	public enum RepositorySystem {
-		NexusOSS("org.jenkinsci.artifactpromotion.NexusOSSPromotor");
+		NexusOSS(NexusOSSPromotor.class.getName());
 		
 		private String className;
 		


### PR DESCRIPTION
The NexusOSSPromotor classname for the enum is now added via the
getName() method of the class in order to be robust in case of refactoring
etc.

This fixes the issue that generated configuration needs to be saved
manually in order to work.