### PR TITLE
Allow promoting POM artifact and debug in delete function

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,29 @@ Untick 'Skip deletion' only after you've promoted all the relevant files in prev
 
 By default, the option *Skip deletion* is enabled.
 
+## Promotion POM artifacts
+
+Is possible to promote POM atifacts, like parent POM or multi module project descriptor, specifying the POM to be promoted and indicating the extension `pom`.
+
+```
+stage('example') {
+    artifactPromotion (
+        promoterClass: 'org.jenkinsci.plugins.artifactpromotion.NexusOSSPromotor',
+        groupId: 'com.example.test',
+        artifactId: 'my-pom-artifact',
+        version: '1.0.0',
+        extension: 'pom',
+        stagingRepository: 'http://nexus.myorg.com:8080/content/repositories/release-candidates',
+        stagingUser: 'foo',
+        stagingPW: 's3cr3t',
+        skipDeletion: true,
+        releaseRepository: 'http://nexus.myorg.com:8080/content/repositories/releases',
+        releaseUser: 'foo',
+        releasePW: 's3cr3t'
+    )
+}
+```
+
 # Contributions
 Please feel free to contribute for other repository servers like
 
@@ -121,6 +144,7 @@ Don't hesitate to come up with your suggestions. Pull requests are preferred as 
 
 # History
 
+* 0.5.2 - Allow promoting POM artifacts. Fix debug functionality in the delete function. 
 * 0.5.1 - Support for Jenkins Pipelines and minor bug fixes; upgrade dependency to Job DSL 1.69, Upgrade used Aether version, fixes some FindBugs findings
 * 0.4.0 - Support for Maven Classifiers
 * 0.3.6 - Support for Job DSL Plugin 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,14 @@
           <role>contributor</role>
         </roles>
       </contributor>
+      <contributor>
+        <name>Nicolas Fantoni</name>
+        <email>fantoni.nico@gmail.com</email>
+        <url>https://github.com/nfantoni</url>
+        <roles>
+            <role>contributor</role>
+        </roles>
+      </contributor>
     </contributors>
 
     <properties>

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/AbstractPromotor.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/AbstractPromotor.java
@@ -51,7 +51,7 @@ public abstract class AbstractPromotor extends ExtensionPoint implements Promoto
     private Secret releasePassword;
 
     private boolean skipDeletion;
-
+    private boolean debug;
 
     public void setLocalRepositoryURL(String localRepositoryURL) {
         this.localRepositoryURL = localRepositoryURL;
@@ -67,7 +67,7 @@ public abstract class AbstractPromotor extends ExtensionPoint implements Promoto
     }
 
     protected Map<PromotionBuildTokens, String> getExpandedTokens() {
-        if(expandedTokens == null) {
+        if (expandedTokens == null) {
             expandedTokens = new HashMap<PromotionBuildTokens, String>(0);
         }
         return expandedTokens;
@@ -125,8 +125,16 @@ public abstract class AbstractPromotor extends ExtensionPoint implements Promoto
         return skipDeletion;
     }
 
+    protected boolean isDebug() {
+        return debug;
+    }
+
     public void setSkipDeletion(Boolean skipDeletion) {
         this.skipDeletion = skipDeletion;
+    }
+
+    public void setDebug(Boolean debug) {
+        this.debug = debug;
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/ArtifactPromotionHelper.java
@@ -185,6 +185,7 @@ public class ArtifactPromotionHelper implements Serializable {
         artifactPromotor.setStagingPassword(stagingPW);
         artifactPromotor.setStagingUser(stagingUser);
         artifactPromotor.setSkipDeletion(skipDeletion);
+        artifactPromotor.setDebug(debug);
 
         String localRepoPath = workspace.getRemote() + File.separator
                 + this.localRepoLocation;

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/NexusOSSPromoterClosure.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/NexusOSSPromoterClosure.java
@@ -48,6 +48,7 @@ public class NexusOSSPromoterClosure implements Serializable, IPromotorClosure {
     private Secret stagingPassword;
     private boolean skipDeletion;
     private TaskListener listener;
+    private boolean debug;
 
 
     /**
@@ -66,7 +67,7 @@ public class NexusOSSPromoterClosure implements Serializable, IPromotorClosure {
             Map<PromotionBuildTokens, String> expandedTokens,
             String releaseUser, Secret releasePassword,
             String stagingUser, Secret stagingPassword,
-            boolean skipDeletion) {
+            boolean skipDeletion, boolean debug) {
         super();
 
         this.expandedTokens = expandedTokens;
@@ -77,6 +78,7 @@ public class NexusOSSPromoterClosure implements Serializable, IPromotorClosure {
         this.stagingPassword = stagingPassword;
         this.localRepositoryURL = localRepositoryURL;
         this.skipDeletion = skipDeletion;
+        this.debug = debug;
     }
 
     /* (non-Javadoc)
@@ -176,7 +178,7 @@ public class NexusOSSPromoterClosure implements Serializable, IPromotorClosure {
     private void deleteArtifact(RemoteRepository aetherStagingRepo,
             ArtifactWrapper artifact) {
         IDeleteArtifact deleter = new DeleteArtifactNexusOSS(this.listener, this.stagingUser,
-                this.stagingPassword, false);
+                this.stagingPassword, this.debug);
         deleter.deleteArtifact(aetherStagingRepo, artifact.getArtifact());
     }
 

--- a/src/main/java/org/jenkinsci/plugins/artifactpromotion/NexusOSSPromotor.java
+++ b/src/main/java/org/jenkinsci/plugins/artifactpromotion/NexusOSSPromotor.java
@@ -54,7 +54,8 @@ public class NexusOSSPromotor extends AbstractPromotor {
                 getReleasePassword(),
                 getStagingUser(),
                 getStagingPassword(),
-                isSkipDeletion());
+                isSkipDeletion(),
+                isDebug());
 
         RemotePromoter promotorTask = new RemotePromoter(promotor);
 


### PR DESCRIPTION
Hi,
using the plugin with multimodule project, when try to promote the parent pom it fails because try two time to update pom in release repo. I fix this and the propagation of debug param in delete function that was fixed to "false"